### PR TITLE
Use defusedxml.

### DIFF
--- a/ospd_nmap_nse/wrapper.py
+++ b/ospd_nmap_nse/wrapper.py
@@ -27,6 +27,7 @@ import string
 import subprocess
 import nmap
 import xml.etree.ElementTree as ET
+import defusedxml.ElementTree as secET
 
 from os import listdir
 from itertools import product
@@ -242,7 +243,7 @@ class OSPDnmap_nse(OSPDaemon):
         if result is None:
             return False
 
-        tree = ET.fromstring(result)
+        tree = secET.fromstring(result)
         if tree.tag != 'nmaprun':
             return False
 


### PR DESCRIPTION
Use defusedxml.fromstring instead of xml.etree.ElementTree.fromstring
to parse unstrusted XML data, since it is know to be vulnerable to XML
attacks.